### PR TITLE
feat: restrict routes for landing page launch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./client
+        run: npm ci
+
+      - name: Build
+        working-directory: ./client
+        env:
+          VITE_ENABLE_INTERNAL_ROUTES: "false"
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./client/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,8 +1,15 @@
-VITE_SERVER_URL=
-VITE_HTTPS_ENABLE=true
+# Environment Variables for Cognia Client
 
-VITE_HTTPS_KEY_PATH=./certs/app.cognia.test+3-key.pem
-VITE_HTTPS_CERT_PATH=./certs/app.cognia.test+3.pem
+# Enable/disable internal routes (memories, search, docs, analytics, profile, insights, login)
+# Set to "false" in production to restrict access to landing page only
+# Set to "true" or leave unset for local development to enable all routes
+VITE_ENABLE_INTERNAL_ROUTES=true
 
-VITE_DEV_HOST=
-VITE_DEV_PORT=5173
+# HTTPS Configuration (optional)
+# VITE_HTTPS_ENABLE=true
+# VITE_HTTPS_KEY_PATH=./certs/app.cognia.test+3-key.pem
+# VITE_HTTPS_CERT_PATH=./certs/app.cognia.test+3.pem
+
+# Development Server Configuration (optional)
+# VITE_DEV_HOST=localhost
+# VITE_DEV_PORT=5173

--- a/client/src/router/routes.route.tsx
+++ b/client/src/router/routes.route.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react"
-import { Route, Routes } from "react-router-dom"
+import { Navigate, Route, Routes } from "react-router-dom"
 
 const Landing = lazy(() =>
   import("@/pages/landing.page").then((module) => ({ default: module.Landing }))
@@ -39,17 +39,34 @@ const LoadingFallback = () => (
 )
 
 const AppRoutes = () => {
+  const enableInternalRoutes =
+    import.meta.env.VITE_ENABLE_INTERNAL_ROUTES !== "false"
+
   return (
     <Suspense fallback={<LoadingFallback />}>
       <Routes>
         <Route path="/" element={<Landing />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/memories" element={<Memories />} />
-        <Route path="/search" element={<Search />} />
-        <Route path="/docs" element={<Docs />} />
-        <Route path="/analytics" element={<Analytics />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/insights" element={<Insights />} />
+        {enableInternalRoutes ? (
+          <>
+            <Route path="/login" element={<Login />} />
+            <Route path="/memories" element={<Memories />} />
+            <Route path="/search" element={<Search />} />
+            <Route path="/docs" element={<Docs />} />
+            <Route path="/analytics" element={<Analytics />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/insights" element={<Insights />} />
+          </>
+        ) : (
+          <>
+            <Route path="/login" element={<Navigate to="/" replace />} />
+            <Route path="/memories" element={<Navigate to="/" replace />} />
+            <Route path="/search" element={<Navigate to="/" replace />} />
+            <Route path="/docs" element={<Navigate to="/" replace />} />
+            <Route path="/analytics" element={<Navigate to="/" replace />} />
+            <Route path="/profile" element={<Navigate to="/" replace />} />
+            <Route path="/insights" element={<Navigate to="/" replace />} />
+          </>
+        )}
 
         <Route path="*" element={<Landing />} />
       </Routes>


### PR DESCRIPTION
Restrict internal routes in production while keeping landing page accessible. All internal routes redirect to landing page when `VITE_ENABLE_INTERNAL_ROUTES=false`.

- Add route restriction based on environment variable
- Add GitHub Pages deployment workflow
- Add environment variable documentation

Internal routes remain accessible in development for continued feature work.