### PR TITLE
fix(api): qdrant query retry + bind dev compose ports to 127.0.0.1

### DIFF
--- a/api/docker-compose.override.yml
+++ b/api/docker-compose.override.yml
@@ -1,4 +1,4 @@
 services:
   redis:
     ports: !override
-      - '6380:6379'
+      - '127.0.0.1:6380:6379'

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_DB: cognia
       POSTGRES_INITDB_ARGS: '--encoding=UTF-8 --lc-collate=C --lc-ctype=C'
     ports:
-      - '5432:5432'
+      - '127.0.0.1:5432:5432'
     volumes:
       - cognia_data:/var/lib/postgresql/data
       - ./init-scripts:/docker-entrypoint-initdb.d
@@ -27,8 +27,8 @@ services:
     container_name: cognia_qdrant
     restart: unless-stopped
     ports:
-      - '6333:6333'
-      - '6334:6334'
+      - '127.0.0.1:6333:6333'
+      - '127.0.0.1:6334:6334'
     volumes:
       - cognia_qdrant_data:/qdrant/storage
     healthcheck:
@@ -47,7 +47,7 @@ services:
     restart: unless-stopped
     command: ['redis-server', '--appendonly', 'yes']
     ports:
-      - '6379:6379'
+      - '127.0.0.1:6379:6379'
     volumes:
       - cognia_redis_data:/data
     healthcheck:
@@ -92,7 +92,7 @@ services:
     ports:
       # Defaults to 3100 to avoid colliding with a host dev server on 3000.
       # Override with: API_HOST_PORT=3000 docker compose --profile app up
-      - '${API_HOST_PORT:-3100}:3000'
+      - '127.0.0.1:${API_HOST_PORT:-3100}:3000'
     # Inherit application secrets and config from .env. The container-network
     # URLs below override the localhost values in that file. Cookie/CORS
     # settings are inherited from .env so dev (.env COOKIE_SECURE=false,
@@ -136,7 +136,7 @@ services:
     container_name: cognia_client
     restart: unless-stopped
     ports:
-      - '${CLIENT_HOST_PORT:-5173}:80'
+      - '127.0.0.1:${CLIENT_HOST_PORT:-5173}:80'
     depends_on:
       api:
         condition: service_healthy

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,7 +15,7 @@
         "@google/genai": "^1.24.0",
         "@node-saml/node-saml": "^5.1.0",
         "@prisma/client": "^6.19.0",
-        "@qdrant/js-client-rest": "^1.9.0",
+        "@qdrant/js-client-rest": "^1.17.0",
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^2.0.0",
@@ -1884,14 +1884,13 @@
       }
     },
     "node_modules/@qdrant/js-client-rest": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.15.1.tgz",
-      "integrity": "sha512-FAPMz6Z7RFj9vUun8R9e8SYcX6EkZtdfYfnh5lFXWcjEaat9q/jce1baAJCWAr3k8yHh62HpzCRYOatLVII28g==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.17.0.tgz",
+      "integrity": "sha512-aZFQeirWVqWAa1a8vJ957LMzcXkFHGbsoRhzc8AkGfg6V0jtK8PlG8/eyyc2xhYsR961FDDx1Tx6nyE0K7lS+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@qdrant/openapi-typescript-fetch": "1.2.6",
-        "@sevinf/maybe": "0.5.0",
-        "undici": "^6.0.0"
+        "undici": "^6.23.0"
       },
       "engines": {
         "node": ">=18.17.0",
@@ -1910,12 +1909,6 @@
         "node": ">=18.0.0",
         "pnpm": ">=8"
       }
-    },
-    "node_modules/@sevinf/maybe": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@sevinf/maybe/-/maybe-0.5.0.tgz",
-      "integrity": "sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg==",
-      "license": "MIT"
     },
     "node_modules/@slack/logger": {
       "version": "4.0.0",
@@ -7451,9 +7444,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
-      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/api/package.json
+++ b/api/package.json
@@ -70,7 +70,7 @@
     "@google/genai": "^1.24.0",
     "@node-saml/node-saml": "^5.1.0",
     "@prisma/client": "^6.19.0",
-    "@qdrant/js-client-rest": "^1.9.0",
+    "@qdrant/js-client-rest": "^1.17.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^2.0.0",

--- a/api/src/lib/qdrant.lib.ts
+++ b/api/src/lib/qdrant.lib.ts
@@ -1,6 +1,7 @@
 import { QdrantClient } from '@qdrant/js-client-rest'
 import { logger } from '../utils/core/logger.util'
 import { getConfiguredEmbeddingDimension } from '../services/ai/ai-config'
+import { retryWithBackoff } from '../utils/core/retry.util'
 import type { SparseVector } from './sparse-encoder.lib'
 
 const globalForQdrant = globalThis as unknown as {
@@ -14,6 +15,22 @@ const COLLECTION_NAME = 'memory_embeddings'
 
 export const DENSE_VECTOR_NAME = 'dense_content'
 export const SPARSE_VECTOR_NAME = 'sparse_bm25'
+
+const QDRANT_QUERY_MAX_RETRIES = 2
+const QDRANT_QUERY_BASE_DELAY_MS = 75
+const QDRANT_QUERY_MAX_DELAY_MS = 300
+
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+])
 
 interface QdrantClientOptions {
   url: string
@@ -32,6 +49,106 @@ let ensureCollectionPromise: Promise<void> | null = null
 
 if (process.env.NODE_ENV !== 'production') {
   globalForQdrant.qdrant = qdrantClient
+}
+
+type QdrantQueryRequest = Parameters<typeof qdrantClient.query>[1]
+type QdrantQueryResult = Awaited<ReturnType<typeof qdrantClient.query>>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object'
+}
+
+function readNumericStatus(value: unknown): number | undefined {
+  if (!isRecord(value)) return undefined
+
+  const status = value.status ?? value.statusCode
+  if (typeof status === 'number') return status
+  if (typeof status === 'string') {
+    const parsed = Number(status)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+
+  return undefined
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (!isRecord(error)) return undefined
+
+  return (
+    readNumericStatus(error) ??
+    readNumericStatus(error.response) ??
+    readNumericStatus(error.cause) ??
+    readStatusFromMessage(getErrorMessage(error))
+  )
+}
+
+function readStatusFromMessage(message: string): number | undefined {
+  const match = message.match(/\b(?:Unexpected Response:|status(?: code)?[:=]?)\s*(\d{3})\b/i)
+  if (!match) return undefined
+
+  const parsed = Number(match[1])
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  const candidates = isRecord(error) ? [error, error.cause] : []
+
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) continue
+    const code = candidate.code
+    if (typeof code === 'string') return code.toUpperCase()
+    if (typeof code === 'number') return String(code)
+  }
+
+  return undefined
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (isRecord(error) && typeof error.message === 'string') return error.message
+  return String(error)
+}
+
+function isTransientQdrantQueryError(error: unknown): boolean {
+  const status = getErrorStatus(error)
+  if (status !== undefined) {
+    return status === 408 || status === 429 || status >= 500
+  }
+
+  const code = getErrorCode(error)
+  if (code && TRANSIENT_NETWORK_ERROR_CODES.has(code)) return true
+
+  if (
+    error instanceof Error &&
+    (error.name === 'AbortError' ||
+      error.name === 'TimeoutError' ||
+      error.name === 'QdrantClientTimeoutError' ||
+      error.name === 'QdrantClientResourceExhaustedError')
+  ) {
+    return true
+  }
+
+  return /\b(fetch failed|network error|socket hang up|connection reset|connection refused|timed?out)\b/i.test(
+    getErrorMessage(error)
+  )
+}
+
+async function queryQdrantWithRetry(request: QdrantQueryRequest): Promise<QdrantQueryResult> {
+  return retryWithBackoff(() => qdrantClient.query(COLLECTION_NAME, request), {
+    maxRetries: QDRANT_QUERY_MAX_RETRIES,
+    baseDelayMs: QDRANT_QUERY_BASE_DELAY_MS,
+    maxDelayMs: QDRANT_QUERY_MAX_DELAY_MS,
+    shouldRetry: isTransientQdrantQueryError,
+    onRetry: (error, attempt, delayMs) => {
+      logger.warn('[qdrant] query failed, retrying', {
+        attempt,
+        delayMs,
+        status: getErrorStatus(error),
+        code: getErrorCode(error),
+        error: getErrorMessage(error),
+      })
+    },
+  })
 }
 
 const PAYLOAD_INDEXES: Array<{
@@ -256,7 +373,7 @@ export async function searchDense(opts: {
   withVector?: boolean
 }): Promise<QdrantPoint[]> {
   await ensureCollection()
-  const result = await qdrantClient.query(COLLECTION_NAME, {
+  const result = await queryQdrantWithRetry({
     query: opts.vector,
     using: DENSE_VECTOR_NAME,
     filter: opts.filter,
@@ -278,7 +395,7 @@ export async function searchSparse(opts: {
   withPayload?: boolean
 }): Promise<QdrantPoint[]> {
   await ensureCollection()
-  const result = await qdrantClient.query(COLLECTION_NAME, {
+  const result = await queryQdrantWithRetry({
     query: { indices: opts.sparse.indices, values: opts.sparse.values },
     using: SPARSE_VECTOR_NAME,
     filter: opts.filter,
@@ -312,7 +429,7 @@ export async function searchHybrid(opts: {
     })
   }
 
-  const result = await qdrantClient.query(COLLECTION_NAME, {
+  const result = await queryQdrantWithRetry({
     prefetch: [
       {
         query: opts.dense,

--- a/api/src/services/memory/mesh-relations.service.ts
+++ b/api/src/services/memory/mesh-relations.service.ts
@@ -23,7 +23,8 @@ export class MeshRelationsService {
   private cacheExpiry = 24 * 60 * 60 * 1000
 
   constructor() {
-    setInterval(() => this.cleanCache(), 60 * 60 * 1000)
+    const cleanupInterval = setInterval(() => this.cleanCache(), 60 * 60 * 1000)
+    cleanupInterval.unref?.()
   }
 
   private cleanCache(): void {


### PR DESCRIPTION
## Summary

- Wraps `qdrantClient.query` with `retryWithBackoff` handling transient network errors (`ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`, `UND_ERR_*`).
- Bumps `@qdrant/js-client-rest` to `^1.17.0`.
- `MeshRelationsService` cleanup `setInterval` now `.unref()`s so it doesn't keep the event loop alive on shutdown.
- Binds postgres / qdrant / redis dev compose ports to `127.0.0.1` so containers aren't reachable on the LAN by default.