### PR TITLE
fix(api): /v1/search advertises mode + Warning header for personal keys

### DIFF
--- a/api/src/routes/v1.route.ts
+++ b/api/src/routes/v1.route.ts
@@ -111,6 +111,7 @@ router.post('/search', requireScope('search'), async (req: ApiKeyRequest, res: R
       userId: req.apiKey!.userId,
     })
     res.json({
+      mode: 'hybrid',
       data: out.results.map(result => ({
         id: result.memoryId,
         title: result.title,
@@ -129,7 +130,11 @@ router.post('/search', requireScope('search'), async (req: ApiKeyRequest, res: R
     return
   }
 
-  // Personal API key (no org): fall back to user-scoped substring match.
+  // Personal API key (no org): substring match against the user's own
+  // memories. This is intentionally lower-quality than the org-scoped
+  // hybrid retrieval — the response advertises mode='substring' and a
+  // Warning header so clients can detect the degraded quality and
+  // surface an org-key upgrade path.
   const items = await prisma.memory.findMany({
     where: {
       user_id: req.apiKey!.userId,
@@ -142,7 +147,12 @@ router.post('/search', requireScope('search'), async (req: ApiKeyRequest, res: R
     take: limit,
     orderBy: { created_at: 'desc' },
   })
+  res.setHeader(
+    'Warning',
+    '299 - "Personal API keys use substring search. For hybrid retrieval, mint a key inside an organization."'
+  )
   res.json({
+    mode: 'substring',
     data: items.map(m => ({
       id: m.id,
       title: m.title,


### PR DESCRIPTION
## Summary

Personal API keys (no organization scope) currently fall back to a naive ILIKE substring match instead of the hybrid retrieval available to org-scoped keys. The behavior is preserved (existing callers don't break) but the response now:

- Includes `mode: "hybrid"` for org keys and `mode: "substring"` for personal keys.
- Adds a `Warning` HTTP header on substring-mode responses so SDK consumers can surface an upgrade path.

A real fix (routing personal keys through the hybrid pipeline) requires `unifiedSearchService` to accept a personal-vault context — separate, larger PR.