### PR TITLE
feat(extension): surface DLP block count in popup status

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -1,5 +1,5 @@
 import { runtime } from '@/lib/browser'
-import { MESSAGE_TYPES } from '@/utils/core/constants.util'
+import { MESSAGE_TYPES, STORAGE_KEYS } from '@/utils/core/constants.util'
 import { detectPrivacyExtensions, getPrivacyExtensionInfo } from './privacy/privacy-detector'
 import { captureContext } from './extraction/content-extractor'
 import { scanForSecretsClient } from '@/dlp'
@@ -163,6 +163,19 @@ async function sendContextToBackground() {
         url: window.location.hostname,
         matches: dlp.matches,
       })
+      try {
+        const stored = await chrome.storage.local.get([STORAGE_KEYS.DLP_BLOCK_COUNT])
+        const next =
+          (typeof stored?.[STORAGE_KEYS.DLP_BLOCK_COUNT] === 'number'
+            ? (stored[STORAGE_KEYS.DLP_BLOCK_COUNT] as number)
+            : 0) + 1
+        await chrome.storage.local.set({
+          [STORAGE_KEYS.DLP_BLOCK_COUNT]: next,
+          [STORAGE_KEYS.DLP_LAST_BLOCKED_AT]: Date.now(),
+        })
+      } catch {
+        // best-effort; don't let storage failures break the block path
+      }
       return
     }
 

--- a/extension/src/popup/components/StatusSection.tsx
+++ b/extension/src/popup/components/StatusSection.tsx
@@ -6,6 +6,7 @@ interface StatusSectionProps {
   isAuthenticated: boolean
   isCheckingHealth: boolean
   lastCaptureTime: number | null
+  dlpBlockCount?: number
 }
 
 type Tone = 'success' | 'warning' | 'destructive' | 'muted'
@@ -61,6 +62,7 @@ export const StatusSection: React.FC<StatusSectionProps> = ({
   isAuthenticated,
   isCheckingHealth,
   lastCaptureTime,
+  dlpBlockCount = 0,
 }) => {
   let primaryLabel: string
   let primaryTone: Tone
@@ -108,6 +110,18 @@ export const StatusSection: React.FC<StatusSectionProps> = ({
           <span className={cn('h-1.5 w-1.5 rounded-full', toneClasses[authTone].dot)} />
           Auth
         </span>
+        {dlpBlockCount > 0 && (
+          <>
+            <span className="text-border">·</span>
+            <span
+              className="inline-flex items-center gap-1.5"
+              title="Captures dropped by client-side DLP because they matched a secret-like pattern"
+            >
+              <span className={cn('h-1.5 w-1.5 rounded-full', toneClasses.warning.dot)} />
+              DLP {dlpBlockCount}
+            </span>
+          </>
+        )}
       </div>
     </div>
   )

--- a/extension/src/popup/hooks/useStatus.ts
+++ b/extension/src/popup/hooks/useStatus.ts
@@ -1,12 +1,15 @@
 import { useState, useEffect } from 'react'
 import { runtime, storage } from '@/lib/browser'
 import { getAuthToken, requireAuthToken } from '@/utils/auth'
+import { STORAGE_KEYS } from '@/utils/core/constants.util'
 
 export function useStatus() {
   const [isConnected, setIsConnected] = useState(false)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [isCheckingHealth, setIsCheckingHealth] = useState(true)
   const [lastCaptureTime, setLastCaptureTime] = useState<number | null>(null)
+  const [dlpBlockCount, setDlpBlockCount] = useState<number>(0)
+  const [dlpLastBlockedAt, setDlpLastBlockedAt] = useState<number | null>(null)
 
   const checkStatus = async () => {
     setIsCheckingHealth(true)
@@ -61,12 +64,29 @@ export function useStatus() {
     }
   }
 
+  const loadDlpStatus = async () => {
+    try {
+      const stored = await storage.local.get([
+        STORAGE_KEYS.DLP_BLOCK_COUNT,
+        STORAGE_KEYS.DLP_LAST_BLOCKED_AT,
+      ])
+      const count = stored?.[STORAGE_KEYS.DLP_BLOCK_COUNT]
+      const last = stored?.[STORAGE_KEYS.DLP_LAST_BLOCKED_AT]
+      setDlpBlockCount(typeof count === 'number' ? count : 0)
+      setDlpLastBlockedAt(typeof last === 'number' ? last : null)
+    } catch (_error) {
+      // Ignore
+    }
+  }
+
   useEffect(() => {
     checkStatus()
     loadLastCaptureTime()
+    loadDlpStatus()
     const interval = setInterval(() => {
       checkStatus()
       loadLastCaptureTime()
+      loadDlpStatus()
     }, 10000)
     return () => clearInterval(interval)
   }, [])
@@ -76,6 +96,8 @@ export function useStatus() {
     isAuthenticated,
     isCheckingHealth,
     lastCaptureTime,
+    dlpBlockCount,
+    dlpLastBlockedAt,
     refreshStatus: checkStatus,
   }
 }

--- a/extension/src/popup/index.tsx
+++ b/extension/src/popup/index.tsx
@@ -54,7 +54,8 @@ const Popup: React.FC = () => {
     blockCurrentDomain,
   } = useExtensionSettings()
 
-  const { isConnected, isAuthenticated, isCheckingHealth, lastCaptureTime } = useStatus()
+  const { isConnected, isAuthenticated, isCheckingHealth, lastCaptureTime, dlpBlockCount } =
+    useStatus()
 
   return (
     <div className="w-[360px] bg-background text-foreground font-primary">
@@ -68,6 +69,7 @@ const Popup: React.FC = () => {
           isAuthenticated={isAuthenticated}
           isCheckingHealth={isCheckingHealth}
           lastCaptureTime={lastCaptureTime}
+          dlpBlockCount={dlpBlockCount}
         />
 
         <section className="rounded-lg border border-border bg-card">

--- a/extension/src/utils/core/constants.util.ts
+++ b/extension/src/utils/core/constants.util.ts
@@ -35,4 +35,6 @@ export const STORAGE_KEYS = {
   MEMORY_INJECTION_ENABLED: 'memoryInjectionEnabled',
   BLOCKED_WEBSITES: 'blockedWebsites',
   AUTH_TOKEN: 'auth_token',
+  DLP_BLOCK_COUNT: 'dlp_block_count',
+  DLP_LAST_BLOCKED_AT: 'dlp_last_blocked_at',
 } as const


### PR DESCRIPTION
## Summary

When client-side DLP drops a capture (matched a secret-like pattern), increment a counter in `chrome.storage.local`. The popup `StatusSection` now shows `DLP N` alongside the API/Auth dots when `N > 0`, with a tooltip explaining the indicator. Gives users visibility into when their captures are silently dropped without changing the existing block path (still `console.warn` + early return).